### PR TITLE
Get latest changes from the upstream repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.11
+FROM alpine:3.13
 ARG VERSION=1.15.0
 
 # Inspiration from https://github.com/gmr/alpine-pgbouncer/blob/master/Dockerfile
 RUN \
   # Download
-  apk --update add autoconf autoconf-doc automake udns udns-dev curl gcc libc-dev libevent libevent-dev libtool make man openssl-dev pkgconfig postgresql-client && \
+  apk --update add autoconf autoconf-doc automake udns udns-dev curl gcc libc-dev libevent libevent-dev libtool make openssl-dev pkgconfig postgresql-client && \
   curl -o  /tmp/pgbouncer-$VERSION.tar.gz -L https://pgbouncer.github.io/downloads/files/$VERSION/pgbouncer-$VERSION.tar.gz && \
   cd /tmp && \
   # Unpack, compile
@@ -24,7 +24,7 @@ RUN \
   # Cleanup
   cd /tmp && \
   rm -rf /tmp/pgbouncer*  && \
-  apk del --purge autoconf autoconf-doc automake udns-dev curl gcc libc-dev libevent-dev libtool make man libressl-dev pkgconfig
+  apk del --purge autoconf autoconf-doc automake udns-dev curl gcc libc-dev libevent-dev libtool make libressl-dev pkgconfig
 ADD entrypoint.sh /entrypoint.sh
 USER postgres
 EXPOSE 5432

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.11
-ARG VERSION=1.12.0
+FROM alpine:3.12
+ARG VERSION=1.14.0
 
 # Inspiration from https://github.com/gmr/alpine-pgbouncer/blob/master/Dockerfile
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.11
-ARG VERSION=1.14.0
+ARG VERSION=1.15.0
 
 # Inspiration from https://github.com/gmr/alpine-pgbouncer/blob/master/Dockerfile
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,12 @@ RUN \
   # Manual install
   cp pgbouncer /usr/bin && \
   mkdir -p /etc/pgbouncer /var/log/pgbouncer /var/run/pgbouncer && \
-  # entrypoint installs the configuation, allow to write as postgres user
+  # entrypoint installs the configuration, allow to write as postgres user
   cp etc/pgbouncer.ini /etc/pgbouncer/pgbouncer.ini.example && \
   cp etc/userlist.txt /etc/pgbouncer/userlist.txt.example && \
+  touch /etc/pgbouncer/userlist.txt && \
   addgroup -g 70 -S postgres 2>/dev/null && \
   adduser -u 70 -S -D -H -h /var/lib/postgresql -g "Postgres user" -s /bin/sh -G postgres postgres 2>/dev/null && \
-  touch /etc/pgbouncer/userlist.txt && \
   chown -R postgres /var/run/pgbouncer /etc/pgbouncer && \
   # Cleanup
   cd /tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN \
   cp etc/userlist.txt /etc/pgbouncer/userlist.txt.example && \
   addgroup -g 70 -S postgres 2>/dev/null && \
   adduser -u 70 -S -D -H -h /var/lib/postgresql -g "Postgres user" -s /bin/sh -G postgres postgres 2>/dev/null && \
+  touch /etc/pgbouncer/userlist.txt && \
   chown -R postgres /var/run/pgbouncer /etc/pgbouncer && \
   # Cleanup
   cd /tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN \
   cd /tmp && \
   rm -rf /tmp/pgbouncer*  && \
   apk del --purge autoconf autoconf-doc automake udns-dev curl gcc libc-dev libevent-dev libtool make libressl-dev pkgconfig
-ADD entrypoint.sh /entrypoint.sh
+
+COPY entrypoint.sh /entrypoint.sh
 USER postgres
 EXPOSE 5432
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.13
 ARG VERSION=1.15.0
 
 # Inspiration from https://github.com/gmr/alpine-pgbouncer/blob/master/Dockerfile
+# hadolint ignore=DL3003,DL3018
 RUN \
   # Download
   apk --update add autoconf autoconf-doc automake udns udns-dev curl gcc libc-dev libevent libevent-dev libtool make openssl-dev pkgconfig postgresql-client && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.11
 ARG VERSION=1.14.0
 
 # Inspiration from https://github.com/gmr/alpine-pgbouncer/blob/master/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ ARG VERSION=1.15.0
 # Inspiration from https://github.com/gmr/alpine-pgbouncer/blob/master/Dockerfile
 # hadolint ignore=DL3003,DL3018
 RUN \
+  # security
+  apk add -U --no-cache --upgrade busybox && \
   # Download
-  apk --update add autoconf autoconf-doc automake udns udns-dev curl gcc libc-dev libevent libevent-dev libtool make openssl-dev pkgconfig postgresql-client && \
+  apk add -U --no-cache autoconf autoconf-doc automake udns udns-dev curl gcc libc-dev libevent libevent-dev libtool make openssl-dev pkgconfig postgresql-client && \
   curl -o  /tmp/pgbouncer-$VERSION.tar.gz -L https://pgbouncer.github.io/downloads/files/$VERSION/pgbouncer-$VERSION.tar.gz && \
   cd /tmp && \
   # Unpack, compile

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-all:
-	docker build --pull -t edoburu/pgbouncer .
+IMAGE_NAME=lapierre/pgbouncer
+IMAGE_VERSION=1.14.0
 
-clean:
-	docker rmi edoburu/pgbouncer:latest
+docker:
+	        docker build -t $(IMAGE_NAME):$(IMAGE_VERSION) .
+			docker tag $(IMAGE_NAME):$(IMAGE_VERSION) $(IMAGE_NAME):latest
+
+push:
+			docker push $(IMAGE_NAME):$(IMAGE_VERSION)
+			docker push $(IMAGE_NAME):latest

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-IMAGE_NAME=lapierre/pgbouncer
+IMAGE_NAME=edoburu/pgbouncer
 IMAGE_VERSION=1.14.0
 
 docker:
-	        docker build -t $(IMAGE_NAME):$(IMAGE_VERSION) .
-			docker tag $(IMAGE_NAME):$(IMAGE_VERSION) $(IMAGE_NAME):latest
+	docker build -t $(IMAGE_NAME):$(IMAGE_VERSION) .
+	docker tag $(IMAGE_NAME):$(IMAGE_VERSION) $(IMAGE_NAME):latest
 
 push:
-			docker push $(IMAGE_NAME):$(IMAGE_VERSION)
-			docker push $(IMAGE_NAME):latest
+	docker push $(IMAGE_NAME):$(IMAGE_VERSION)
+	docker push $(IMAGE_NAME):latest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME=edoburu/pgbouncer
-IMAGE_VERSION=1.14.0
+IMAGE_VERSION=1.15.0
 
 docker:
 	docker build -t $(IMAGE_NAME):$(IMAGE_VERSION) .

--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ Available tags
 Base images:
 
 - `latest` ([Dockerfile](https://github.com/edoburu/docker-pgbouncer/blob/master/Dockerfile)) - Default and latest version.
+- `1.15.0` ([Dockerfile](https://github.com/edoburu/docker-pgbouncer/blob/v1.15.x/Dockerfile)) - Latest version.
+- `1.14.0` ([Dockerfile](https://github.com/edoburu/docker-pgbouncer/blob/v1.14.x/Dockerfile)) - Latest version.
 - `1.12.0` ([Dockerfile](https://github.com/edoburu/docker-pgbouncer/blob/v1.12.x/Dockerfile)) - Latest version.
-- `1.11.0` ([Dockerfile](https://github.com/edoburu/docker-pgbouncer/blob/v1.11.x/Dockerfile)) - previous version.
-- `1.9.0` ([Dockerfile](https://github.com/edoburu/docker-pgbouncer/blob/v1.9.x/Dockerfile))
-- `1.8.1` ([Dockerfile](https://github.com/edoburu/docker-pgbouncer/blob/v1.8.x/Dockerfile))
 
 Images are automatically rebuild on Alpine Linux updates.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Kubernetes integration
 For example in Kubernetes, see the [examples/kubernetes folder](https://github.com/edoburu/docker-pgbouncer/tree/master/examples/kubernetes).
 
 
+Docker Compose
+--------------
+
+For example in Docker Compose, see the [examples/docker-compose folder](https://github.com/alapierre/docker-pgbouncer/tree/master/examples/docker-compose).
+
+
 PostgreSQL configuration
 ------------------------
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ For example in Kubernetes, see the [examples/kubernetes folder](https://github.c
 Docker Compose
 --------------
 
-For example in Docker Compose, see the [examples/docker-compose folder](https://github.com/alapierre/docker-pgbouncer/tree/master/examples/docker-compose).
+For example in Docker Compose, see the [examples/docker-compose folder](https://github.com/edoburu/docker-pgbouncer/tree/master/examples/docker-compose).
 
 
 PostgreSQL configuration

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,6 +40,13 @@ fi
 # Write the password with MD5 encryption, to avoid printing it during startup.
 # Notice that `docker inspect` will show unencrypted env variables.
 _AUTH_FILE="${AUTH_FILE:-$PG_CONFIG_DIR/userlist.txt}"
+
+# Workaround userlist.txt missing issue
+# https://github.com/edoburu/docker-pgbouncer/issues/33
+if [ ! -e "${_AUTH_FILE}" ]; then
+  touch "${_AUTH_FILE}"
+fi
+
 if [ -n "$DB_USER" -a -n "$DB_PASSWORD" -a -e "${_AUTH_FILE}" ] && ! grep -q "^\"$DB_USER\"" "${_AUTH_FILE}"; then
   if [ "$AUTH_TYPE" != "plain" ]; then
      pass="md5$(echo -n "$DB_PASSWORD$DB_USER" | md5sum | cut -f 1 -d ' ')"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,8 @@ fi
 
 # Write the password with MD5 encryption, to avoid printing it during startup.
 # Notice that `docker inspect` will show unencrypted env variables.
-if [ -n "$DB_USER" -a -n "$DB_PASSWORD" ] && ! grep -q "^\"$DB_USER\"" ${PG_CONFIG_DIR}/userlist.txt; then
+_AUTH_FILE="${AUTH_FILE:-$PG_CONFIG_DIR/userlist.txt}"
+if [ -n "$DB_USER" -a -n "$DB_PASSWORD" -a -e "${_AUTH_FILE}" ] && ! grep -q "^\"$DB_USER\"" "${_AUTH_FILE}"; then
   if [ "$AUTH_TYPE" != "plain" ]; then
      pass="md5$(echo -n "$DB_PASSWORD$DB_USER" | md5sum | cut -f 1 -d ' ')"
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -140,6 +140,7 @@ ${TCP_KEEPALIVE:+tcp_keepalive = ${TCP_KEEPALIVE}\n}\
 ${TCP_KEEPCNT:+tcp_keepcnt = ${TCP_KEEPCNT}\n}\
 ${TCP_KEEPIDLE:+tcp_keepidle = ${TCP_KEEPIDLE}\n}\
 ${TCP_KEEPINTVL:+tcp_keepintvl = ${TCP_KEEPINTVL}\n}\
+${TCP_USER_TIMEOUT:+tcp_user_timeout = ${TCP_USER_TIMEOUT}\n}\
 ################## end file ##################
 " > ${PG_CONFIG_DIR}/pgbouncer.ini
 cat ${PG_CONFIG_DIR}/pgbouncer.ini

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -1,4 +1,4 @@
-Docker compose sample
+### Docker compose sample
 
 Usage:
 

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -1,0 +1,10 @@
+Docker compose sample
+
+Usage:
+
+```
+docker-compose up -d
+psql postgres://dbuser:hbZkzny5xrvVH@localhost/test 
+```
+
+

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - POSTGRES_DB=test
 
   pgbouncer:
-    image: lapierre/pgbouncer
+    image: edoburu/pgbouncer
     environment:
        - DB_USER=dbuser
        - DB_PASSWORD=hbZkzny5xrvVH

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:  
+
+  db:
+    image: postgres:12
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=hbZkzny5xrvVH
+      - POSTGRES_USER=dbuser
+      - POSTGRES_DB=test
+
+  pgbouncer:
+    image: lapierre/pgbouncer
+    environment:
+       - DB_USER=dbuser
+       - DB_PASSWORD=hbZkzny5xrvVH
+       - DB_HOST=db
+       - DB_NAME=test 
+       - POOL_MODE=transaction
+       - ADMIN_USERS=postgres,dbuser
+    ports:
+      - "5432:5432"
+    depends_on:
+      - db
+
+volumes:
+  pg_data:


### PR DESCRIPTION
This includes an upgrade to pgbouncer 1.15.0, which has a fix for the problem of health checks generating noisy logs: https://github.com/pgbouncer/pgbouncer/pull/526.